### PR TITLE
Make OpenAI api server host and port configurable from TTS-Webui config.json

### DIFF
--- a/extension_kokoro_tts_api/main.py
+++ b/extension_kokoro_tts_api/main.py
@@ -180,7 +180,7 @@ def ui():
 def startup_ui():
     with gr.Row():
         with gr.Column():
-            url = f"""{get_config_value("extension_kokoro_tts_api", "host", "0.0.0.0")}:{get_config_value("extension_kokoro_tts_api", "port", 7778)}"""
+            url = f"""localhost:{get_config_value("extension_kokoro_tts_api", "port", 7778)}"""
             gr.Markdown(
                 f"""
                 This extension adds an API endpoint for the Kokoro TTS & Chatterbox models. You can use this to generate audio from text.

--- a/extension_kokoro_tts_api/main.py
+++ b/extension_kokoro_tts_api/main.py
@@ -12,8 +12,10 @@ from tts_webui.config.config_utils import get_config_value, set_config_value
 #     get_api_status,
 # )
 
+
 def activate_api(host=None, port=None):
-    host = host or get_config_value("extension_kokoro_tts_api", "host", "0.0.0.0")
+    host = host or get_config_value(
+        "extension_kokoro_tts_api", "host", "0.0.0.0")
     port = port or get_config_value("extension_kokoro_tts_api", "port", 7778)
     from .api import app
 
@@ -38,7 +40,8 @@ def get_api_status():
 
 
 def test_api(host=None, port=None):
-    host = host or get_config_value("extension_kokoro_tts_api", "host", "0.0.0.0")
+    host = host or get_config_value(
+        "extension_kokoro_tts_api", "host", "0.0.0.0")
     port = port or get_config_value("extension_kokoro_tts_api", "port", 7778)
     import requests
 
@@ -63,14 +66,16 @@ def test_api(host=None, port=None):
 
 
 def test_api_with_open_ai(host=None, port=None):
-    host = host or get_config_value("extension_kokoro_tts_api", "host", "0.0.0.0")
+    host = host or get_config_value(
+        "extension_kokoro_tts_api", "host", "0.0.0.0")
     port = port or get_config_value("extension_kokoro_tts_api", "port", 7778)
     from openai import OpenAI
 
     if host == "0.0.0.0":
         host = "localhost"
 
-    client = OpenAI(api_key="sk-1234567890", base_url=f"http://{host}:{port}/v1")
+    client = OpenAI(api_key="sk-1234567890",
+                    base_url=f"http://{host}:{port}/v1")
 
     with client.audio.speech.with_streaming_response.create(
         model="hexgrad/Kokoro-82M",
@@ -189,19 +194,23 @@ def startup_ui():
 
             host = gr.Textbox(
                 label="Host",
-                value=lambda: get_config_value("extension_kokoro_tts_api", "host", "0.0.0.0")
+                value=lambda: get_config_value(
+                    "extension_kokoro_tts_api", "host", "0.0.0.0")
             )
             port = gr.Number(
                 label="Port",
-                value=lambda: get_config_value("extension_kokoro_tts_api", "port", 7778)
+                value=lambda: get_config_value(
+                    "extension_kokoro_tts_api", "port", 7778)
             )
             host.change(
-                fn=lambda x: set_config_value("extension_kokoro_tts_api", "host", x),
+                fn=lambda x: set_config_value(
+                    "extension_kokoro_tts_api", "host", x),
                 inputs=[host],
                 outputs=[]
             )
             port.change(
-                fn=lambda x: set_config_value("extension_kokoro_tts_api", "port", x),
+                fn=lambda x: set_config_value(
+                    "extension_kokoro_tts_api", "port", x),
                 inputs=[port],
                 outputs=[]
             )
@@ -216,10 +225,12 @@ def startup_ui():
 
             auto_start_api = gr.Checkbox(
                 label="Auto start API",
-                value=lambda: get_config_value("extension_kokoro_tts_api", "auto_start", False),
+                value=lambda: get_config_value(
+                    "extension_kokoro_tts_api", "auto_start", False),
             )
             auto_start_api.change(
-                fn=lambda x: set_config_value("extension_kokoro_tts_api", "auto_start", x),
+                fn=lambda x: set_config_value(
+                    "extension_kokoro_tts_api", "auto_start", x),
                 inputs=[auto_start_api],
                 outputs=[],
             )
@@ -255,7 +266,7 @@ def startup_ui():
             import requests
 
             response = requests.post(
-                "http://localhost:{PORT}/v1/audio/speech",
+                "http://localhost:7778/v1/audio/speech",
                 json={{
                     "model": "hexgrad/Kokoro-82M",
                     "input": "Hello world with custom parameters.",
@@ -288,7 +299,7 @@ def startup_ui():
             ```python
             from openai import OpenAI
 
-            client = OpenAI(api_key="sk-1234567890", base_url="http://localhost:{PORT}/v1")
+            client = OpenAI(api_key="sk-1234567890", base_url="http://localhost:7778/v1")
 
             with client.audio.speech.with_streaming_response.create(
                 model="hexgrad/Kokoro-82M",

--- a/extension_kokoro_tts_api/main.py
+++ b/extension_kokoro_tts_api/main.py
@@ -12,11 +12,9 @@ from tts_webui.config.config_utils import get_config_value, set_config_value
 #     get_api_status,
 # )
 
-PORT = 7778
-HOST = "0.0.0.0"
-
-
-def activate_api(host=HOST, port=PORT):
+def activate_api(host=None, port=None):
+    host = host or get_config_value("extension_kokoro_tts_api", "host", "0.0.0.0")
+    port = port or get_config_value("extension_kokoro_tts_api", "port", 7778)
     from .api import app
 
     import uvicorn
@@ -39,7 +37,9 @@ def get_api_status():
     return {"status": "not implemented"}
 
 
-def test_api(host=HOST, port=PORT):
+def test_api(host=None, port=None):
+    host = host or get_config_value("extension_kokoro_tts_api", "host", "0.0.0.0")
+    port = port or get_config_value("extension_kokoro_tts_api", "port", 7778)
     import requests
 
     if host == "0.0.0.0":
@@ -62,7 +62,9 @@ def test_api(host=HOST, port=PORT):
     return audio
 
 
-def test_api_with_open_ai(host=HOST, port=PORT):
+def test_api_with_open_ai(host=None, port=None):
+    host = host or get_config_value("extension_kokoro_tts_api", "host", "0.0.0.0")
+    port = port or get_config_value("extension_kokoro_tts_api", "port", 7778)
     from openai import OpenAI
 
     if host == "0.0.0.0":
@@ -179,14 +181,30 @@ def startup_ui():
                 
                 To use the API, you need to activate it. This will start the API server and you can then use the API endpoint.
                 
-                The default API endpoint is http://localhost:{PORT}/v1/audio/speech
+                The default API endpoint is http://{get_config_value("extension_kokoro_tts_api", "host", "0.0.0.0")}:{get_config_value("extension_kokoro_tts_api", "port", 7778)}/v1/audio/speech
                 
-                The default OpenAI API Base_url is http://localhost:{PORT}/v1/
+                The default OpenAI API Base_url is http://{get_config_value("extension_kokoro_tts_api", "host", "0.0.0.0")}:{get_config_value("extension_kokoro_tts_api", "port", 7778)}/v1/
                 """
             )
 
-            host = gr.Textbox(label="Host", value=HOST)
-            port = gr.Number(label="Port", value=PORT)
+            host = gr.Textbox(
+                label="Host",
+                value=lambda: get_config_value("extension_kokoro_tts_api", "host", "0.0.0.0")
+            )
+            port = gr.Number(
+                label="Port",
+                value=lambda: get_config_value("extension_kokoro_tts_api", "port", 7778)
+            )
+            host.change(
+                fn=lambda x: set_config_value("extension_kokoro_tts_api", "host", x),
+                inputs=[host],
+                outputs=[]
+            )
+            port.change(
+                fn=lambda x: set_config_value("extension_kokoro_tts_api", "port", x),
+                inputs=[port],
+                outputs=[]
+            )
 
             activate_api_btn = gr.Button("Activate API")
             activate_api_btn.click(

--- a/extension_kokoro_tts_api/main.py
+++ b/extension_kokoro_tts_api/main.py
@@ -180,15 +180,16 @@ def ui():
 def startup_ui():
     with gr.Row():
         with gr.Column():
+            url = f"""{get_config_value("extension_kokoro_tts_api", "host", "0.0.0.0")}:{get_config_value("extension_kokoro_tts_api", "port", 7778)}"""
             gr.Markdown(
                 f"""
                 This extension adds an API endpoint for the Kokoro TTS & Chatterbox models. You can use this to generate audio from text.
                 
                 To use the API, you need to activate it. This will start the API server and you can then use the API endpoint.
                 
-                The default API endpoint is http://{get_config_value("extension_kokoro_tts_api", "host", "0.0.0.0")}:{get_config_value("extension_kokoro_tts_api", "port", 7778)}/v1/audio/speech
+                The default API endpoint is http://{url}/v1/audio/speech
                 
-                The default OpenAI API Base_url is http://{get_config_value("extension_kokoro_tts_api", "host", "0.0.0.0")}:{get_config_value("extension_kokoro_tts_api", "port", 7778)}/v1/
+                The default OpenAI API Base_url is http://{url}/v1/
                 """
             )
 
@@ -266,7 +267,7 @@ def startup_ui():
             import requests
 
             response = requests.post(
-                "http://localhost:7778/v1/audio/speech",
+                "http://{url}/v1/audio/speech",
                 json={{
                     "model": "hexgrad/Kokoro-82M",
                     "input": "Hello world with custom parameters.",
@@ -299,7 +300,7 @@ def startup_ui():
             ```python
             from openai import OpenAI
 
-            client = OpenAI(api_key="sk-1234567890", base_url="http://localhost:7778/v1")
+            client = OpenAI(api_key="sk-1234567890", base_url="http://{url}/v1")
 
             with client.audio.speech.with_streaming_response.create(
                 model="hexgrad/Kokoro-82M",


### PR DESCRIPTION
Just makes it so that the openai api server host and port can be configured from config.json of the main app likw this
```
"extension_kokoro_tts_api": {
    "auto_start": true,
    "host": "0.0.0.0",
    "port": 8012
  }
```
It's a draft PR cuz it works for me but I'm not sure if I found ALL of the references to the hardcoded values or not, I'd appreciate another pair of eyes especially the author themselves ^^"